### PR TITLE
Remove timestamp in line before passing to processCommonActions

### DIFF
--- a/main/ipcHandlers.js
+++ b/main/ipcHandlers.js
@@ -190,18 +190,18 @@ function setupIpcHandlers() {
     if (line) {
       const triggers = store.get("triggers");
       actions.forEach(({ actionType, key, search, sound, useRegex }) => {
-        if (actionType === "speak") processSpeakAction(line, key, search, sound, useRegex, actionType);
-        if (actionType === "sound") processSoundAction(line, key, search, sound, useRegex, actionType);
+        if (actionType === "speak") processSpeakAction(lineOnly, key, search, sound, useRegex, actionType);
+        if (actionType === "sound") processSoundAction(lineOnly, key, search, sound, useRegex, actionType);
       });
 
       if (triggers && triggers.length > 0) {
         triggers.map((trigger, index) => {
-          if (trigger.saySomething) processSpeakAction(line, "", trigger.searchText, trigger.speechText, trigger.searchRegex);
+          if (trigger.saySomething) processSpeakAction(lineOnly, "", trigger.searchText, trigger.speechText, trigger.searchRegex);
           if (trigger.playSound) {
             const soundFile = typeof triggers[index]?.sound === "string" ? triggers[index].sound.replace(".mp3", "") : undefined;
-            processSoundAction(line, "", trigger.searchText, soundFile, trigger.searchRegex);
+            processSoundAction(lineOnly, "", trigger.searchText, soundFile, trigger.searchRegex);
           }
-          if (trigger.setTimer) processTimerAction(line, "", trigger.searchText, trigger.searchRegex, trigger);
+          if (trigger.setTimer) processTimerAction(lineOnly, "", trigger.searchText, trigger.searchRegex, trigger);
         });
       }
 


### PR DESCRIPTION
In processCommonActions, processSpeakAction, processSoundAction, processTimerAction can take lineOnly as an argument to have the timestamp removed before they pass that line to processCommonActions. This fixes being able to use ^ in regex as expected. 

As an aside, it might be worth considering always using start of the line when matching search text. Otherwise, someone could spam another users triggers intentionally.